### PR TITLE
Add Docker image build workflows

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,36 @@
+on:
+  workflow_call:
+    outputs:
+      sha-tag:
+        description: The SHA tag of the built image
+        value: ${{ jobs.build-images.outputs.sha-tag }}
+
+jobs:
+  build-images:
+    runs-on: ubuntu-24.04
+
+    outputs:
+      sha-tag: ${{ steps.image.outputs.imageid }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: violet-lambda
+
+      - name: Build image
+        id: image
+        uses: docker/build-push-action@v7
+        with:
+          context: applications/violet_lambda_function
+          file: applications/violet_lambda_function/Dockerfile
+          push: false
+          provenance: mode=max
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -1,0 +1,6 @@
+on:
+  pull_request:
+
+jobs:
+  build-images:
+    uses: ./.github/workflows/build-images.yml


### PR DESCRIPTION
## Summary\n- add a reusable workflow to build the Violet Lambda Docker image in CI\n- trigger the image build from pull request checks\n- configure the workflow to use the repository's existing Dockerfile path\n