### PR TITLE
Add Docker image build workflows

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,33 @@
+on:
+  workflow_call:
+    outputs:
+      sha-tag:
+        description: The SHA tag of the built image
+        value: ${{ jobs.build-images.outputs.sha-tag }}
+
+jobs:
+  build-images:
+    runs-on: ubuntu-24.04
+
+    outputs:
+      sha-tag: ${{ steps.meta.outputs.version }}
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: violet-lambda
+          tags: |
+            type=sha
+
+      - name: Build image
+        uses: docker/build-push-action@v7
+        with:
+          context: "{{defaultContext}}:applications/violet_lambda_function"
+          push: false
+          provenance: mode=max
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -1,0 +1,6 @@
+on:
+  pull_request:
+
+jobs:
+  build-images:
+    uses: ./.github/workflows/build-images.yml


### PR DESCRIPTION
## Summary
- add a reusable workflow to build the Violet Lambda Docker image
- run the image build in pull request checks
- expose the generated SHA tag from the reusable workflow
